### PR TITLE
feat: smarte Pagination mit Ellipsis, First/Last-Navigation (#443)

### DIFF
--- a/browsing/templates/browsing/partials/pagination.html
+++ b/browsing/templates/browsing/partials/pagination.html
@@ -1,49 +1,76 @@
 {% load django_tables2 %}
 {% load i18n %}
+{% load pagination_tags %}
 
 <div>
     {% with table.page.object_list|length as count %}
         <p class="float-center">Page total: {{ count }}</p>
     {% endwith %}
 </div>
-{% if table.paginator.page_range|length > 25 %}
-<div class="form-group mb-3">
-    <label for="goto">Go to page</label>
-    <select class="form-control" id="goto" onchange="javascript:location.href = this.value;">
+
+<nav aria-label="Pagination of the results table">
+    <ul class="pagination flex-wrap">
+
+        {% comment %}First page{% endcomment %}
+        <li class="page-item {% if not table.page.has_previous %}disabled{% endif %}">
+            <a class="page-link" href="{% querystring table.prefixed_page_field=1 %}" aria-label="First">
+                <span aria-hidden="true">&laquo;&laquo;</span>
+            </a>
+        </li>
+
+        {% comment %}Previous page{% endcomment %}
+        <li class="page-item {% if not table.page.has_previous %}disabled{% endif %}">
+            <a class="page-link"
+               href="{% if table.page.has_previous %}{% querystring table.prefixed_page_field=table.page.previous_page_number %}{% else %}#{% endif %}"
+               aria-label="Previous">
+                <span aria-hidden="true">&laquo;</span>
+            </a>
+        </li>
+
+        {% comment %}Smart page window with ellipsis{% endcomment %}
+        {% smart_page_range table.page.number table.paginator.num_pages as page_range %}
+        {% for p in page_range %}
+            {% if p is None %}
+                <li class="page-item disabled">
+                    <span class="page-link">&hellip;</span>
+                </li>
+            {% elif p == table.page.number %}
+                <li class="page-item active" aria-current="page">
+                    <span class="page-link">{{ p }}</span>
+                </li>
+            {% else %}
+                <li class="page-item">
+                    <a class="page-link" href="{% querystring table.prefixed_page_field=p %}">{{ p }}</a>
+                </li>
+            {% endif %}
+        {% endfor %}
+
+        {% comment %}Next page{% endcomment %}
+        <li class="page-item {% if not table.page.has_next %}disabled{% endif %}">
+            <a class="page-link"
+               href="{% if table.page.has_next %}{% querystring table.prefixed_page_field=table.page.next_page_number %}{% else %}#{% endif %}"
+               aria-label="Next">
+                <span aria-hidden="true">&raquo;</span>
+            </a>
+        </li>
+
+        {% comment %}Last page{% endcomment %}
+        <li class="page-item {% if not table.page.has_next %}disabled{% endif %}">
+            <a class="page-link" href="{% querystring table.prefixed_page_field=table.paginator.num_pages %}" aria-label="Last">
+                <span aria-hidden="true">&raquo;&raquo;</span>
+            </a>
+        </li>
+
+    </ul>
+</nav>
+
+{% if table.paginator.num_pages > 10 %}
+<div class="d-flex align-items-center gap-2 mb-3">
+    <label for="goto" class="mb-0 text-nowrap">Seite {{ table.page.number }} von {{ table.paginator.num_pages }} &mdash; Gehe zu:</label>
+    <select class="form-control form-control-sm w-auto" id="goto" onchange="javascript:location.href = this.value;">
         {% for p in table.paginator.page_range %}
-            <option value="{% querystring table.prefixed_page_field=p %}">{{ p }}</option>
+            <option value="{% querystring table.prefixed_page_field=p %}"{% if p == table.page.number %} selected{% endif %}>{{ p }}</option>
         {% endfor %}
     </select>
 </div>
-{% else %}
-<nav aria-label="Pagination of the results table">
-    <ul class="pagination">
-    {% if table.page.has_previous %}
-        {% block pagination.previous %}
-        <li class="page-item">
-            <a class="page-link" href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}" aria-label="Previous"><span aria-hidden="true">&laquo;</span>
-            </a>
-        </li>
-        {% endblock pagination.previous %}
-    {% endif %}
-    {% for p in table.paginator.page_range %}
-        {% if p == table.page.number %}
-            <li class="page-item active" aria-current="page">
-                <a class="page-link" href="#">{{ p }}</a>
-            </li>
-        {% else %}
-            <li class="page-item">
-                <a class="page-link" href="{% querystring table.prefixed_page_field=p %}"> {{ p }}</a>
-            </li>
-        {% endif %}
-    {% endfor %}
-    {% if table.page.has_next %}
-        {% block pagination.next %}
-        <li class="page-item">
-            <a class="page-link" href="{% querystring table.prefixed_page_field=table.page.next_page_number %}" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
-        </li>
-        {% endblock pagination.next %}
-    {% endif %}
-    </ul>
-</nav>
 {% endif %}

--- a/browsing/templatetags/pagination_tags.py
+++ b/browsing/templatetags/pagination_tags.py
@@ -1,0 +1,25 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def smart_page_range(current, num_pages, delta=2):
+    """Return a list of page numbers with None as ellipsis placeholder."""
+    pages = []
+    left = max(1, current - delta)
+    right = min(num_pages, current + delta)
+
+    if left > 1:
+        pages.append(1)
+        if left > 2:
+            pages.append(None)
+
+    pages.extend(range(left, right + 1))
+
+    if right < num_pages:
+        if right < num_pages - 1:
+            pages.append(None)
+        pages.append(num_pages)
+
+    return pages

--- a/browsing/tests.py
+++ b/browsing/tests.py
@@ -1,3 +1,57 @@
-# from django.test import TestCase
+from django.test import TestCase
 
-# Create your tests here.
+from browsing.templatetags.pagination_tags import smart_page_range
+
+
+class SmartPageRangeTestCase(TestCase):
+    def test_single_page(self):
+        self.assertEqual(smart_page_range(1, 1), [1])
+
+    def test_small_range_no_ellipsis(self):
+        self.assertEqual(smart_page_range(3, 5), [1, 2, 3, 4, 5])
+
+    def test_first_page_large_range(self):
+        result = smart_page_range(1, 50)
+        self.assertEqual(result[0], 1)
+        self.assertIn(None, result)
+        self.assertEqual(result[-1], 50)
+        self.assertNotIn(None, result[:3])
+
+    def test_last_page_large_range(self):
+        result = smart_page_range(50, 50)
+        self.assertEqual(result[0], 1)
+        self.assertIn(None, result)
+        self.assertEqual(result[-1], 50)
+
+    def test_middle_page_both_ellipsis(self):
+        result = smart_page_range(10, 50)
+        self.assertEqual(result[0], 1)
+        self.assertEqual(result[-1], 50)
+        self.assertIn(None, result)
+        self.assertIn(10, result)
+        self.assertIn(8, result)
+        self.assertIn(12, result)
+        self.assertNotIn(7, result)
+        self.assertNotIn(13, result)
+        none_indices = [i for i, p in enumerate(result) if p is None]
+        self.assertEqual(len(none_indices), 2)
+
+    def test_near_start_single_ellipsis(self):
+        result = smart_page_range(3, 50)
+        self.assertEqual(result[0], 1)
+        self.assertEqual(result[-1], 50)
+        none_indices = [i for i, p in enumerate(result) if p is None]
+        self.assertEqual(len(none_indices), 1)
+
+    def test_near_end_single_ellipsis(self):
+        result = smart_page_range(48, 50)
+        self.assertEqual(result[0], 1)
+        self.assertEqual(result[-1], 50)
+        none_indices = [i for i, p in enumerate(result) if p is None]
+        self.assertEqual(len(none_indices), 1)
+
+    def test_no_duplicate_pages(self):
+        for current in [1, 2, 3, 4, 5, 25, 46, 47, 48, 49, 50]:
+            result = smart_page_range(current, 50)
+            pages_only = [p for p in result if p is not None]
+            self.assertEqual(len(pages_only), len(set(pages_only)))


### PR DESCRIPTION
Closes #443

## Summary

- Ersetzt die bisherige zweigeteilte Pagination (Dropdown für >25 Seiten / alle Seitenbuttons für ≤25 Seiten) durch eine einheitliche Komponente
- Neuer Template Tag `smart_page_range` berechnet das Seitenfenster (aktuelle Seite ±2) mit Ellipsis-Markierungen
- Navigation: `[««]` Erste Seite, `[«]` Vorherige, Seitennummern mit `…`, `[»]` Nächste, `[»»]` Letzte Seite
- Bei mehr als 10 Seiten: "Seite X von Y — Gehe zu:" Dropdown mit vorausgewählter aktueller Seite

## Beispiel

```
[««] [«]  1 … 8 9 [10] 11 12 … 50  [»] [»»]
Seite 10 von 50 — Gehe zu: [▼]
```

## Test plan

- [ ] Listansicht mit vielen Seiten aufrufen und Ellipsis-Anzeige prüfen
- [ ] First/Last-Buttons navigieren korrekt
- [ ] "Gehe zu"-Dropdown zeigt aktuelle Seite vorausgewählt
- [ ] Bei wenigen Seiten (≤10): kein Dropdown, alle Seitennummern sichtbar, kein Ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)