### PR TITLE
fix: Wikidata-URI ergänzen, wenn Entität über geonames/gnd gematcht wird (#231)

### DIFF
--- a/normdata/tests.py
+++ b/normdata/tests.py
@@ -1,6 +1,9 @@
+from acdh_wikidata_pyutils import WikiDataPlace
+from AcdhArcheAssets.uri_norm_rules import get_normalized_uri
 from django.test import TestCase
 from pylobid.pylobid import PyLobidPerson
 
+from apis_core.apis_entities.models import Place
 from apis_core.apis_metainfo.models import Uri
 from normdata.utils import (
     get_gender_from_pylobid,
@@ -8,6 +11,7 @@ from normdata.utils import (
     get_or_create_person_from_gnd,
     get_or_create_place_from_geonames,
     get_or_create_place_from_gnd,
+    get_or_create_place_from_wikidata,
     import_from_normdata,
 )
 
@@ -67,6 +71,26 @@ class NormdataTestCase(TestCase):
             "https://www.geonames.org/2516696/marisma-de-hinojos.html", "place"
         )
         self.assertTrue(entity.kind)
+
+    def test_008_wikidata_uri_added_when_matched_via_geonames(self):
+        # https://github.com/arthur-schnitzler/pmb-service/issues/231
+        # Importing the "Schlossberg" (Q264176) via wikidata matches an existing
+        # place by its geonames URI; the wikidata URI must still be added.
+        wikidata_url = "https://www.wikidata.org/wiki/Q264176"
+        wd_entity = WikiDataPlace(wikidata_url)
+        place = Place.objects.create(name="Schlossberg")
+        Uri.objects.create(
+            uri=get_normalized_uri(wd_entity.geonames_uri),
+            domain="geonames",
+            entity=place,
+        )
+        normalized_wd = get_normalized_uri(wikidata_url)
+        self.assertFalse(Uri.objects.filter(uri=normalized_wd).exists())
+        entity = get_or_create_place_from_wikidata(wikidata_url)
+        self.assertEqual(entity.id, place.id)
+        self.assertTrue(
+            Uri.objects.filter(uri=normalized_wd, entity=place).exists()
+        )
 
     def test_007_check_for_wiengeschichte(self):
         wiengeschichte_uri = (

--- a/normdata/utils.py
+++ b/normdata/utils.py
@@ -36,6 +36,24 @@ def get_uri_domain(uri):
             return x[1]
 
 
+def add_uri_to_entity(entity, uri, domain):
+    """Adds a (normalized) URI to an existing entity, unless it is already stored.
+
+    Used when an entity is matched via one normdata URI (e.g. geonames or gnd)
+    while being imported via another (e.g. wikidata), so that the URI used for
+    the import does not get lost.
+    """
+    if not uri:
+        return
+    normalized = get_normalized_uri(uri)
+    if Uri.objects.filter(uri=normalized).exists():
+        return
+    try:
+        Uri.objects.create(uri=normalized, domain=domain, entity=entity)
+    except IntegrityError:
+        pass
+
+
 def get_gender_from_pylobid(fetched_item):
     ent_dict = fetched_item.get_entity_json()
     try:
@@ -113,11 +131,13 @@ def get_or_create_place_from_wikidata(uri):
         try:
             entity = Uri.objects.get(uri=wd_entity.geonames_uri).entity
             entity = Place.objects.get(id=entity.id)
+            add_uri_to_entity(entity, uri, "wikidata")
             return entity
         except ObjectDoesNotExist:
             try:
                 entity = Uri.objects.get(uri=wd_entity.gnd_uri).entity
                 entity = Place.objects.get(id=entity.id)
+                add_uri_to_entity(entity, uri, "wikidata")
                 return entity
             except ObjectDoesNotExist:
                 apis_entity = wd_entity.get_apis_entity()
@@ -219,6 +239,7 @@ def get_or_create_person_from_wikidata(uri):
         try:
             entity = Uri.objects.get(uri=wd_entity.gnd_uri).entity
             entity = Person.objects.get(id=entity.id)
+            add_uri_to_entity(entity, uri, "wikidata")
             return entity
         except ObjectDoesNotExist:
             apis_entity = wd_entity.get_apis_entity()
@@ -341,6 +362,7 @@ def get_or_create_work_from_wikidata(uri):
             try:
                 entity = Uri.objects.get(uri=wd_entity.gnd_uri).entity
                 entity = Work.objects.get(id=entity.id)
+                add_uri_to_entity(entity, uri, "wikidata")
                 return entity
             except ObjectDoesNotExist:
                 entity = get_or_create_work_from_gnd(wd_entity.gnd_uri)
@@ -371,6 +393,7 @@ def get_or_create_org_from_wikidata(uri):
         try:
             entity = Uri.objects.get(uri=wd_entity.gnd_uri).entity
             entity = Institution.objects.get(id=entity.id)
+            add_uri_to_entity(entity, uri, "wikidata")
             return entity
         except ObjectDoesNotExist:
             apis_entity = wd_entity.get_apis_entity()


### PR DESCRIPTION
Fixes #231

## Problem

Beim Import einer Entität über Wikidata (z. B. der Grazer Schlossberg, https://www.wikidata.org/wiki/Q264176) wird geprüft, ob die Entität bereits existiert. Die Entität wurde über ihre **geonames-** bzw. **gnd-URI** erkannt und zurückgegeben – die eigentlich importierte **Wikidata-URI wurde dabei aber nicht gespeichert**.

## Ursache

Der Import liegt in der `normdata`-App. In `get_or_create_place_from_wikidata` (und den Pendants für Person/Werk/Institution) wird die vorhandene Entität nacheinander über Wikidata-, geonames- und gnd-URI gesucht. Bei einem Treffer über geonames/gnd wurde die Entität sofort `return`t, ohne die Wikidata-URI zu ergänzen.

## Fix

Neue Hilfsfunktion `add_uri_to_entity(entity, uri, domain)`, die die (normalisierte) URI an die gematchte Entität hängt, sofern sie noch nicht existiert (Schutz gegen Duplikate / `IntegrityError`). Aufruf in allen vier `get_or_create_*_from_wikidata`-Funktionen an den Stellen, an denen eine bestehende Entität über eine andere Normdaten-URI gefunden wird.

## Test

`test_008_wikidata_uri_added_when_matched_via_geonames` bildet genau den Schlossberg-Fall ab: vorhandener Place nur mit geonames-URI, Import via Wikidata → gleiche Entität wird zurückgegeben **und** die Wikidata-URI ist nun gespeichert.

> ⚠️ Konnte lokal nicht ausgeführt werden (kein PostgreSQL/Docker verfügbar; die Tests greifen zudem live auf Wikidata zu). Bitte vor dem Merge `python manage.py test normdata` gegen echtes Postgres + Netzwerk laufen lassen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)