### PR TITLE
fix: TEI-Export von Zeitspannen (#356)

### DIFF
--- a/apis_core/apis_tei/templates/apis_tei/affiliation.xml
+++ b/apis_core/apis_tei/templates/apis_tei/affiliation.xml
@@ -1,13 +1,11 @@
 {% for x in object.personinstitution_set.all %}
 <affiliation
-{% if x.start_start_date %}
-        notBefore-iso="{{ x.start_start_date|date:'Y-m-d' }}"
-      {% endif %}
-      {% if x.start_date %}
+{% if x.start_date and x.end_date and x.start_date != x.end_date %}
+        from-iso="{{ x.start_date|date:'Y-m-d' }}" to-iso="{{ x.end_date|date:'Y-m-d' }}"
+      {% elif x.start_date %}
         when-iso="{{ x.start_date|date:'Y-m-d' }}"
-      {% endif %}
-      {% if x.start_end_date %}
-        notAfter-iso="{{ x.start_end_date|date:'Y-m-d' }}"
+      {% elif x.end_date %}
+        to-iso="{{ x.end_date|date:'Y-m-d' }}"
       {% endif %}
 >
     <term key="{{ x.relation_type.id }}">{{ x.relation_type }}</term>

--- a/apis_core/apis_tei/templates/apis_tei/event.xml
+++ b/apis_core/apis_tei/templates/apis_tei/event.xml
@@ -1,5 +1,5 @@
 
-    <event xml:id="event__{{ object.id }}" when-iso="{{ object.start_date|date:'Y-m-d' }}">
+    <event xml:id="event__{{ object.id }}"{% if object.start_date and object.end_date and object.start_date != object.end_date %} from-iso="{{ object.start_date|date:'Y-m-d' }}" to-iso="{{ object.end_date|date:'Y-m-d' }}"{% elif object.start_date %} when-iso="{{ object.start_date|date:'Y-m-d' }}"{% elif object.end_date %} to-iso="{{ object.end_date|date:'Y-m-d' }}"{% endif %}>
         <eventName {% if object.kind %} n="{{ object.kind }}" {% endif %}>{{ object.name }}</eventName>{% if object.institutionevent_set.all %}
         <note type="listorg">
             <listOrg>{% for x in object.institutionevent_set.all %}

--- a/apis_core/apis_tei/templates/apis_tei/events.xml
+++ b/apis_core/apis_tei/templates/apis_tei/events.xml
@@ -1,14 +1,12 @@
 <listEvent>
     {% for x in object.personevent_set.all %}
     <event {% if x.related_event.kind %} n="{{ x.related_event.kind}}" {% endif %}  key="{{ x.related_event.id }}"
-    {% if x.start_start_date %}
-            notBefore-iso="{{ x.start_start_date|date:'Y-m-d' }}"
-        {% endif %}
-        {% if x.start_date %}
+    {% if x.start_date and x.end_date and x.start_date != x.end_date %}
+            from-iso="{{ x.start_date|date:'Y-m-d' }}" to-iso="{{ x.end_date|date:'Y-m-d' }}"
+        {% elif x.start_date %}
             when-iso="{{ x.start_date|date:'Y-m-d' }}"
-        {% endif %}
-        {% if x.start_end_date %}
-            notAfter-iso="{{ x.start_end_date|date:'Y-m-d' }}"
+        {% elif x.end_date %}
+            to-iso="{{ x.end_date|date:'Y-m-d' }}"
         {% endif %}
     >
         <desc n="{{ x.relation_type.id }}">{{ x.relation_type }}</desc>


### PR DESCRIPTION
## Problem
Manche Events haben Zeitspannen statt eines einzelnen Datums (z. B. [Event 292869](https://pmb.acdh.oeaw.ac.at/apis/entities/entity/event/292869/detail)). Der TEI-Export gab bisher nur das Startdatum als `when-iso` aus – das Enddatum ging verloren.

## Lösung
Einheitliche Regel auf allen betroffenen Templates:

| Bedingung | Ausgabe |
|---|---|
| Start ≠ Ende | `from-iso` + `to-iso` |
| Start == Ende / nur Start | `when-iso` |
| nur Ende | `to-iso` |
| keins | kein Datums-Attribut |

## Betroffene Templates
- `event.xml` – Event-Entitäten (Kern des Issues)
- `affiliation.xml` – Person↔Institution-Relationen (häufig Zeitspannen)
- `events.xml` – Person↔Event-Relationen

In den beiden Relationen-Templates wurde die alte Logik (`notBefore`/`when`/`notAfter` nur auf Startseite) durch die zeitspannenbewusste Logik ersetzt.

`birth_death.xml` bleibt unverändert: Geburt/Tod sind bewusst zwei getrennte Einzeldaten, keine Spanne.

Alle fünf Fälle wurden per Render-Test geprüft.

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)