### PR TITLE
fix: Browser-Autofill in Beziehungs-Formularen deaktivieren (#451)

### DIFF
--- a/apis_core/apis_relations/forms2.py
+++ b/apis_core/apis_relations/forms2.py
@@ -395,3 +395,8 @@ class GenericRelationForm(forms.ModelForm):
                 self.fields[
                     "end_date_written"
                 ].help_text = DateParser.get_date_help_text_default()
+
+        # Prevent browsers (notably Safari on macOS) from offering
+        # contact/email autofill suggestions on these fields.
+        for field in self.fields.values():
+            field.widget.attrs["autocomplete"] = "off"

--- a/apis_core/apis_relations/templates/apis_relations/_ajax_form.html
+++ b/apis_core/apis_relations/templates/apis_relations/_ajax_form.html
@@ -1,4 +1,4 @@
-<form hx-post="/apis/relations/ajax/save/{{ entity_type }}/{{ form_name }}/{{ SiteID }}{% if ObjectID %}/{{ ObjectID }}{% endif %}/" hx-target="#tableDiv__{{ relation_name }}" hx-swap="innerHTML">
+<form autocomplete="off" hx-post="/apis/relations/ajax/save/{{ entity_type }}/{{ form_name }}/{{ SiteID }}{% if ObjectID %}/{{ ObjectID }}{% endif %}/" hx-target="#tableDiv__{{ relation_name }}" hx-swap="innerHTML">
     {% load crispy_forms_tags %}
     {% crispy form form.helper %}
         <button type="submit" class="btn btn-primary">{{ button_text }}</button>

--- a/apis_core/apis_relations/tests.py
+++ b/apis_core/apis_relations/tests.py
@@ -1,1 +1,23 @@
-# Create your tests here.
+from django.test import TestCase
+
+from apis_core.apis_relations.forms2 import GenericRelationForm
+
+
+class GenericRelationFormTestCase(TestCase):
+    fixtures = [
+        "db.json",
+    ]
+
+    def test_autocomplete_off_on_all_fields(self):
+        """All form fields disable browser autofill (see #451)."""
+        form = GenericRelationForm(
+            entity_type="person",
+            relation_form="PersonPlace",
+        )
+        self.assertTrue(form.fields)
+        for name, field in form.fields.items():
+            self.assertEqual(
+                field.widget.attrs.get("autocomplete"),
+                "off",
+                msg=f"field '{name}' is missing autocomplete='off'",
+            )


### PR DESCRIPTION
## Problem

Beim Eingeben von Beziehungen bot Safari auf macOS systemweite Kontakt-/E-Mail-Autofill-Vorschläge in den Formularfeldern an (z.B. eine E-Mail-Adresse in den Datums- oder Notizfeldern).

## Ursache

Die Textfelder des Beziehungs-Formulars (`start_date_written`, `end_date_written`, `notes`, `references`) hatten kein `autocomplete`-Attribut. Safari rät dann heuristisch, es könnte sich um Kontaktfelder handeln, und zeigt Autofill-Vorschläge an.

## Lösung

- `autocomplete="off"` wird in `GenericRelationForm.__init__` auf alle Feld-Widgets gesetzt (deckt Datums-, Notiz- und Select2-Felder ab).
- Zusätzlich `autocomplete="off"` am `<form>`-Tag in `_ajax_form.html`.

## Hinweis / Einschränkung

Safari ignoriert `autocomplete="off"` bei Kontakt-Autofill in manchen Versionen trotzdem. Die Pro-Feld-Attribute wirken erfahrungsgemäß zuverlässiger als nur das Formular-Attribut, aber eine 100%-Garantie gibt es browserseitig nicht.

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)