### PR TITLE
fix: HTML-Code blitzt in Autocomplete-Feldern auf (FOUC) (#453)

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -14,6 +14,16 @@
     min-height: 2.2rem;
 }
 
+/*
+ * Prevent the raw HTML option label (provided via data-html) from
+ * briefly flashing in the native <select> before Select2 initializes
+ * and wraps it (FOUC). Select2 adds the class "select2-hidden-accessible"
+ * to the original <select> once it is ready; until then we hide it.
+ */
+select[data-autocomplete-light-function]:not(.select2-hidden-accessible) {
+    visibility: hidden;
+}
+
 footer a {
     color: var(--pmb);
     text-decoration: underline;


### PR DESCRIPTION
## Problem

Beim Öffnen/Bearbeiten von Beziehungen blitzt in den Autocomplete-Feldern (Select2) kurz der rohe, ungerenderte HTML-Code auf, z.B.:

```
<span ><small>db</small> <b>Astor Theatre</b> <small>db-ID: 44003</small> </span>
```

statt des gerenderten Labels „db **Astor Theatre** db-ID: 44003". Besonders sichtbar in Safari auf macOS – es ist aber **kein Safari-Bug**, sondern ein Flash of Unstyled Content (FOUC) in der App.

## Ursache

Die Autocomplete-Views liefern HTML-Markup als Options-Label (siehe `apis_core/apis_entities/autocomplete3.py`), das erst nach Initialisierung des Select2-JavaScripts gerendert wird (`data-html: True`). Bis dahin zeigt das native `<select>` den Options-Text als rohen Text an.

## Lösung (Option A – CSS)

Das native `<select>` wird ausgeblendet, bis Select2 es übernommen hat. Select2 4.0.5 hängt nach der Initialisierung die Klasse `select2-hidden-accessible` an das Original-`<select>`:

```css
select[data-autocomplete-light-function]:not(.select2-hidden-accessible) {
    visibility: hidden;
}
```

Das gerenderte Select2-Widget (ein Geschwister-`<span>`) bleibt sichtbar – nur der rohe HTML-Flash wird unterdrückt. `visibility` statt `display` vermeidet Layout-Sprünge.

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)