### PR TITLE
Accent-insensitive search with toggle for sensitive search

### DIFF
--- a/apis_core/apis_entities/filters.py
+++ b/apis_core/apis_entities/filters.py
@@ -1,4 +1,5 @@
 import importlib
+import unicodedata
 from functools import reduce
 
 import django_filters
@@ -26,6 +27,24 @@ from apis_core.apis_vocabularies.models import RelationBaseClass
 
 # TODO __sresch__ : Turn the logic of returing a filter object into a singleton pattern to avoid redundant instantiations
 # TODO __sresch__ : use the order of list of filter fields in settings
+
+# Name of the GET parameter used to switch to accent-/diacritic-sensitive search.
+# When it is absent (the default), searches are accent-insensitive, so e.g.
+# "Goth" also matches "Góth". When it is truthy, the original strict matching is used.
+ACCENT_SENSITIVE_PARAM = "accent_sensitive"
+
+
+def remove_accents(value):
+    """
+    Strips diacritics from the given string so that it can be compared against the
+    PostgreSQL ``unaccent()`` of a column (which only transforms the database side).
+    E.g. 'Góth' -> 'Goth'.
+    """
+    return "".join(
+        char
+        for char in unicodedata.normalize("NFKD", value)
+        if not unicodedata.combining(char)
+    )
 
 
 #######################################################################
@@ -145,6 +164,19 @@ class GenericListFilter(django_filters.FilterSet):
 
         self.filters = eliminate_unused_filters(self.filters)
 
+    def is_accent_sensitive(self):
+        """
+        Whether the user requested a strict, accent-/diacritic-sensitive search via
+        the toggle in the search form. Defaults to False (accent-insensitive search).
+        """
+        data = self.data or {}
+        return str(data.get(ACCENT_SENSITIVE_PARAM, "")).lower() in (
+            "1",
+            "true",
+            "on",
+            "yes",
+        )
+
     def construct_lookup(self, value):
         """
         Parses user input for wildcards and returns a tuple containing the interpreted django lookup string and the trimmed value
@@ -154,27 +186,37 @@ class GenericListFilter(django_filters.FilterSet):
             'example*' -> ('__istartswith', 'example')
             '"example"' -> ('__iexact', 'example')
 
+        Unless the user enabled accent-sensitive search, the lookup is prefixed with
+        ``__unaccent`` and the value gets its diacritics stripped, so that e.g.
+        searching for "Goth" also matches "Góth".
+
         :param value : str : text to be parsed for *
         :return: (lookup : str, value : str)
         """
 
         if value.startswith("*") and not value.endswith("*"):
             value = value[1:]
-            return "__iendswith", value
+            lookup = "__iendswith"
 
         elif not value.startswith("*") and value.endswith("*"):
             value = value[:-1]
-            return "__istartswith", value
+            lookup = "__istartswith"
 
         elif value.startswith('"') and value.endswith('"'):
             value = value[1:-1]
-            return "__iexact", value
+            lookup = "__iexact"
 
         else:
             if value.startswith("*") and value.endswith("*"):
                 value = value[1:-1]
 
-            return "__icontains", value
+            lookup = "__icontains"
+
+        if not self.is_accent_sensitive():
+            value = remove_accents(value)
+            lookup = "__unaccent" + lookup
+
+        return lookup, value
 
     def string_wildcard_filter(self, queryset, name, value):
         lookup, value = self.construct_lookup(value)

--- a/apis_core/apis_entities/migrations/0006_unaccent_extension.py
+++ b/apis_core/apis_entities/migrations/0006_unaccent_extension.py
@@ -1,0 +1,12 @@
+from django.contrib.postgres.operations import UnaccentExtension
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("apis_entities", "0005_alter_event_eventb_relationtype_set_and_more"),
+    ]
+
+    operations = [
+        UnaccentExtension(),
+    ]

--- a/browsing/templates/browsing/generic_list.html
+++ b/browsing/templates/browsing/generic_list.html
@@ -35,6 +35,19 @@
                         {% load django_tables2 crispy_forms_tags %}
                         <form action="." class="uniForm" method="get">
                             {% crispy filter.form filter.form.helper %}
+                            <div class="form-check mb-3">
+                                <input class="form-check-input" type="checkbox"
+                                       name="accent_sensitive" value="true"
+                                       id="accent_sensitive_toggle"
+                                       {% if request.GET.accent_sensitive %}checked{% endif %}>
+                                <label class="form-check-label" for="accent_sensitive_toggle">
+                                    Accent-sensitive search
+                                    <small class="text-muted d-block">
+                                        Off by default: &ldquo;Goth&rdquo; also finds &ldquo;G&oacute;th&rdquo;.
+                                        Switch on to distinguish accented characters.
+                                    </small>
+                                </label>
+                            </div>
                             {% include 'browsing/partials/column_selector.html' %}
                             <a class="btn btn-primary"  href=".">Reset</a>
                             <button type="submit" class="btn btn-primary">Search</button>

--- a/pmb/settings.py
+++ b/pmb/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    "django.contrib.postgres",
     "django.contrib.staticfiles",
     "rest_framework",
     "csvexport",


### PR DESCRIPTION
Closes #462.

## Problem
Search distinguished between accented and unaccented characters, so searching for "Goth" did not find "Góth".

## Changes
- **Accent-insensitive by default:** `construct_lookup` in `apis_core/apis_entities/filters.py` now strips diacritics from the search term and prefixes lookups with the PostgreSQL `__unaccent` lookup. All name search methods route through `construct_lookup`, so they all become accent-insensitive (`Goth` ⇄ `Góth`).
- **Toggle button:** an "Accent-sensitive search" checkbox in the browse search form (`generic_list.html`). Off by default (less sensitive); checking it restores the original strict matching. State persists across submissions via `request.GET`.
- **Postgres support:** added `django.contrib.postgres` to `INSTALLED_APPS` (registers the `__unaccent` lookup) and a migration creating the `unaccent` extension.

## Notes
- The migration runs `CREATE EXTENSION unaccent`, which requires the DB role to have privileges to create extensions.
- `unaccent()` on a column is not index-backed; if name searches become slow on large tables, a functional index on `unaccent(name)` would help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)