### PR TITLE
fix: keep coordinates from merged place when target has none

### DIFF
--- a/apis_core/apis_entities/tests.py
+++ b/apis_core/apis_entities/tests.py
@@ -229,6 +229,27 @@ class EntitiesTestCase(TestCase):
         self.assertEqual("1820", target_partial.start_date_written)
         self.assertFalse(target_partial.end_date_written)
 
+    def test_009c_merge_coordinates(self):
+        # target without coordinates inherits them from the merged source
+        target = Place.objects.create(name="Place without coordinates")
+        source = Place.objects.create(
+            name="Place with coordinates", lat=48.2, lng=16.37
+        )
+        target.merge_with(source.id)
+        self.assertEqual(48.2, target.lat)
+        self.assertEqual(16.37, target.lng)
+
+        # target with its own coordinates keeps them, ignoring the source's
+        target_with_coords = Place.objects.create(
+            name="Place which keeps its coordinates", lat=47.07, lng=15.44
+        )
+        source_other_coords = Place.objects.create(
+            name="Place whose coordinates are dropped", lat=48.2, lng=16.37
+        )
+        target_with_coords.merge_with(source_other_coords.id)
+        self.assertEqual(47.07, target_with_coords.lat)
+        self.assertEqual(15.44, target_with_coords.lng)
+
     def test_010_delete_views(self):
         client.login(**USER)
         for x in MODELS:

--- a/apis_core/apis_metainfo/models.py
+++ b/apis_core/apis_metainfo/models.py
@@ -444,6 +444,18 @@ class TempEntityClass(models.Model):
                 self.start_date_written = ent.start_date_written
                 self.end_date_written = ent.end_date_written
                 save_target = True
+            # Inherit coordinates (Place) when the target has none. lat and lng
+            # always go together (see Place.save), so copy both as a pair.
+            if (
+                hasattr(self, "lat")
+                and self.lat is None
+                and self.lng is None
+                and (getattr(ent, "lat", None) is not None
+                     or getattr(ent, "lng", None) is not None)
+            ):
+                self.lat = ent.lat
+                self.lng = ent.lng
+                save_target = True
             if len(notes) > 0:
                 additional_notes = " ".join(notes)
                 self.notes = f"{self.notes} {additional_notes}"


### PR DESCRIPTION
Beim Mergen von Ort B in Ort A gingen bisher die Koordinaten (lat/lng) von B verloren, wenn A keine eigenen Angaben hatte.

Neues Verhalten:
1. A hat Koordinaten → die von A bleiben
2. A hat keine → die von B werden übernommen

lat und lng werden als Paar kopiert, analog zu `Place.save` (das beide immer gemeinsam behandelt). Die Logik ist in `merge_with` per `hasattr(self, "lat")` auf `Place` eingegrenzt und folgt dem Muster der Datums-Vererbung aus #459.

Closes #464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)