### PR TITLE
Allow db-ID input in autocompletes and show first name for persons

### DIFF
--- a/apis_core/apis_entities/autocomplete3.py
+++ b/apis_core/apis_entities/autocomplete3.py
@@ -113,6 +113,9 @@ class GenericEntitiesAutocomplete(autocomplete.Select2ListView):
                 Q(**{x + search_type: q})
                 for x in settings.APIS_ENTITIES[ac_type.title()]["search"]
             ]
+            if q.isdigit() and int(q) < 2**63:
+                # additionally allow looking up an entry by its db-ID
+                arg_list.append(Q(pk=int(q)))
             res = (
                 ent_model.objects.filter(reduce(operator.or_, arg_list))
                 .order_by("id")

--- a/apis_core/apis_entities/tests.py
+++ b/apis_core/apis_entities/tests.py
@@ -489,6 +489,28 @@ class EntitiesTestCase(TestCase):
             r = client.get(f"{url}?q=a")
             self.assertEqual(r.status_code, 200)
 
+    def test_024a_autocomplete_by_id(self):
+        person = Person.objects.create(name="Nachnametest", first_name="Vornametest")
+        url = reverse(
+            "apis:apis_entities:generic_entities_autocomplete",
+            kwargs={"entity": "person"},
+        )
+        r = client.get(f"{url}?q={person.pk}")
+        self.assertEqual(r.status_code, 200)
+        ids = [c["id"] for c in r.json()["results"] if "id" in c]
+        self.assertIn(person.pk, ids)
+
+    def test_024b_uri_autocomplete_by_id_shows_first_name(self):
+        person = Person.objects.create(name="Nachnametest", first_name="Vornametest")
+        url = reverse("apis:apis_metainfo-ac:apis_tempentity-autocomplete")
+        r = client.get(f"{url}?q={person.pk}")
+        self.assertEqual(r.status_code, 200)
+        results = r.json()["results"]
+        ids = [int(c["id"]) for c in results]
+        self.assertIn(person.pk, ids)
+        labels = " ".join(c["text"] for c in results)
+        self.assertIn("Vornametest", labels)
+
     def test_024_vocabs_dl(self):
         models = ["placetype", "worktype"]
         client.login(**USER)

--- a/apis_core/apis_metainfo/dal_views.py
+++ b/apis_core/apis_metainfo/dal_views.py
@@ -1,13 +1,20 @@
 from dal import autocomplete
+from django.db.models import Q
 
 from .models import TempEntityClass
 
 
 class TempEntityClassAC(autocomplete.Select2QuerySetView):
     def get_queryset(self):
-        qs = TempEntityClass.objects.all()
+        # select_subclasses() returns the actual entity instances (e.g. Person),
+        # so __str__ can include the first name instead of only the surname
+        qs = TempEntityClass.objects_inheritance.select_subclasses()
 
         if self.q:
-            qs = qs.filter(name__icontains=self.q)
+            if self.q.isdigit() and int(self.q) < 2**63:
+                # additionally allow looking up an entry by its db-ID
+                qs = qs.filter(Q(name__icontains=self.q) | Q(pk=int(self.q)))
+            else:
+                qs = qs.filter(name__icontains=self.q)
 
         return qs

--- a/apis_core/apis_relations/forms2.py
+++ b/apis_core/apis_relations/forms2.py
@@ -24,19 +24,34 @@ from apis_core.helper_functions import DateParser
 
 from .tables import get_generic_relations_table
 
+DB_ID_VALUE_RE = re.compile(r"db-ID:\s*(\d+)")
+
+
+def normalize_target_autocomplete_value(value):
+    try:
+        numeric_value = int(value)
+        if numeric_value < 2**63:
+            return str(numeric_value)
+    except TypeError, ValueError:
+        pass
+
+    if isinstance(value, str):
+        value = value.strip()
+        db_match = DB_ID_VALUE_RE.search(value)
+        if db_match and int(db_match.group(1)) < 2**63:
+            return db_match.group(1)
+        if value.startswith("http"):
+            return value
+
+    raise ValidationError(
+        _("Invalid value: %(value)s, use either URLs or select a value"),
+        code="invalid",
+        params={"value": value},
+    )
+
 
 def validate_target_autocomplete(value):
-    try:
-        value = int(value)
-    except ValueError:
-        if value.startswith("http"):
-            pass
-        else:
-            raise ValidationError(
-                _("Invalid value: %(value)s, use either URLs or select a value"),
-                code="invalid",
-                params={"value": value},
-            )
+    normalize_target_autocomplete_value(value)
 
 
 class GenericRelationForm(forms.ModelForm):
@@ -47,6 +62,10 @@ class GenericRelationForm(forms.ModelForm):
             "start_date_written": _("Start"),
             "end_date_written": _("End"),
         }
+
+    def clean_target(self):
+        value = self.cleaned_data.get("target")
+        return normalize_target_autocomplete_value(value)
 
     def clean(self):
         cleaned_data = super().clean()

--- a/apis_core/apis_relations/tests.py
+++ b/apis_core/apis_relations/tests.py
@@ -1,6 +1,10 @@
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from apis_core.apis_relations.forms2 import GenericRelationForm
+from apis_core.apis_relations.forms2 import (
+    GenericRelationForm,
+    normalize_target_autocomplete_value,
+)
 
 
 class GenericRelationFormTestCase(TestCase):
@@ -21,3 +25,64 @@ class GenericRelationFormTestCase(TestCase):
                 "off",
                 msg=f"field '{name}' is missing autocomplete='off'",
             )
+
+    def test_normalize_target_autocomplete_value_accepts_numeric_id(self):
+        self.assertEqual(normalize_target_autocomplete_value("44909"), "44909")
+
+    def test_normalize_target_autocomplete_value_extracts_db_id_from_html_label(self):
+        value = (
+            "<span ><small>db</small> <b>Altaussee 43</b> "
+            "<small>db-ID: 44909</small> </span>"
+        )
+        self.assertEqual(normalize_target_autocomplete_value(value), "44909")
+
+    def test_normalize_target_autocomplete_value_accepts_urls(self):
+        value = "https://example.org/entity/123"
+        self.assertEqual(normalize_target_autocomplete_value(value), value)
+
+    def test_normalize_target_autocomplete_value_rejects_plain_text(self):
+        with self.assertRaises(ValidationError) as exc_info:
+            normalize_target_autocomplete_value("Altaussee 43")
+
+        self.assertEqual(exc_info.exception.code, "invalid")
+
+    def test_form_is_valid_and_normalizes_html_target_value(self):
+        form_combinations = [
+            ("person", "PersonPlace"),
+            ("person", "PersonPerson"),
+            ("person", "PersonInstitution"),
+            ("institution", "PersonInstitution"),
+            ("person", "PersonEvent"),
+            ("person", "PersonWork"),
+            ("institution", "InstitutionPlace"),
+            ("institution", "InstitutionInstitution"),
+            ("institution", "InstitutionEvent"),
+            ("institution", "InstitutionWork"),
+            ("place", "PlaceEvent"),
+            ("place", "PlaceWork"),
+            ("place", "PlacePlace"),
+            ("event", "EventWork"),
+            ("event", "EventEvent"),
+            ("work", "WorkWork"),
+        ]
+
+        for entity_type, relation_form in form_combinations:
+            with self.subTest(entity_type=entity_type, relation_form=relation_form):
+                form = GenericRelationForm(
+                    entity_type=entity_type,
+                    relation_form=relation_form,
+                    data={
+                        "relation_type": "1",
+                        "target": (
+                            "<span ><small>db</small> <b>Altaussee 43</b> "
+                            "<small>db-ID: 44909</small> </span>"
+                        ),
+                        "start_date_written": "",
+                        "end_date_written": "",
+                        "references": "",
+                        "notes": "",
+                    },
+                )
+
+                self.assertTrue(form.is_valid(), msg=form.errors.as_json())
+                self.assertEqual(form.cleaned_data["target"], "44909")


### PR DESCRIPTION
## Was

Behebt #471.

In den Autocomplete-Feldern von **Beziehungen**, **Merges** und **neuen URIs** kann man jetzt zusätzlich eine reine db-ID eingeben (z. B. `1234`), um direkt zum entsprechenden Eintrag zu gelangen. Hat die Zahl einen ID-Treffer, erscheint dieser ganz normal im Dropdown. Die bestehende Namenssuche bleibt unverändert.

Außerdem: Im URI-Formular wird bei Personen jetzt auch der **Vorname** angezeigt, nicht mehr nur der Nachname.

## Wie

- `GenericEntitiesAutocomplete` (Beziehungen + Merges): bei rein numerischer Eingabe wird `Q(pk=...)` zusätzlich zur Namenssuche verodert.
- `TempEntityClassAC` (URIs): analoge db-ID-Suche; die Query nutzt jetzt `objects_inheritance.select_subclasses()`, damit echte Subklassen-Instanzen (z. B. `Person`) zurückkommen und `__str__` den Vornamen mit ausgibt.
- `int(q) < 2**63` schützt vor Overflow bei überlangen Zahlen (BigAutoField = 64-Bit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)