### PR TITLE
neue Farbe für schnitzler-bahr

### DIFF
--- a/pmb/settings.py
+++ b/pmb/settings.py
@@ -346,7 +346,7 @@ DOMAIN_MAPPING = [
     ("wikipedia", "wikipedia", "#0645AD"),
     ("fackel.oeaw.ac.at", "fackel", "#CE0F0B"),
     ("schnitzler-tagebuch", "schnitzler-tagebuch", "#037a33"),
-    ("schnitzler-bahr", "schnitzler-bahr", "#F9BD63"),
+    ("schnitzler-bahr", "schnitzler-bahr", "#0369A1"),
     ("schnitzler-briefe", "schnitzler-briefe", "#A63437"),
     ("schnitzler-lektueren", "schnitzler-lektueren", "#022954"),
     ("schnitzler-interviews", "schnitzler-interviews", "#3D5A80"),


### PR DESCRIPTION
Ändert die Domain-Farbe für `schnitzler-bahr` in `DOMAIN_MAPPING` von `#F9BD63` auf `#0369A1`.

Herausgelöst aus dem Branch `471-allow-number-for-merging-and-adding-uris`, damit die Farbänderung unabhängig vom dortigen Feature nach main kann.

🤖 Generated with [Claude Code](https://claude.com/claude-code)