### PR TITLE
feat: adds Zotero-readable metadata to entity detail pages

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/detail_views/entity_detail_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/detail_views/entity_detail_generic.html
@@ -2,6 +2,18 @@
 {% load static %}
 {% load django_tables2 %}
 {% block title %} {{ object }} {% endblock %}
+{% block metaData %}
+<link rel="canonical" href="https://pmb.acdh.oeaw.ac.at/entity/{{ object.id }}/">
+<meta property="og:title" content="{{ object }}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://pmb.acdh.oeaw.ac.at/entity/{{ object.id }}/">
+<meta property="og:site_name" content="PMB – Personen der Moderne Basis">
+{% if object.img_url %}<meta property="og:image" content="{{ object.img_url }}">{% endif %}
+<meta name="DC.title" content="{{ object }}">
+<meta name="DC.identifier" content="https://pmb.acdh.oeaw.ac.at/entity/{{ object.id }}/">
+<meta name="DC.language" content="de">
+<meta name="DC.publisher" content="PMB – Personen der Moderne Basis">
+{% endblock %}
 {% block content %}
 {% include "partials/entity_styles.html" %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
 
 <meta charset="utf-8">
 <title>{% block title %}PMB{% endblock %}</title>
+{% block metaData %}{% endblock %}
 
 {% include "partials/head.html" %}
 {% block scriptHeader %}{% endblock scriptHeader %}


### PR DESCRIPTION
Closes #479

Adds a `metaData` block to `base.html` and fills it on all entity detail pages (person, place, work, event, institution) with:

- `<link rel="canonical">` pointing to the stable PMB-URI (`https://pmb.acdh.oeaw.ac.at/entity/{id}/`)
- Open Graph tags (`og:title`, `og:type`, `og:url`, `og:site_name`, `og:image` if available)
- Dublin Core tags (`DC.title`, `DC.identifier`, `DC.language`, `DC.publisher`)

Zotero's Embedded Metadata translator reads these, so saving a PMB page yields a proper webpage item with the entity name as title and the stable PMB-URI as URL.

**Caveat:** This alone does not fix Citoid (e.g. Wikipedia's automatic citation tool). The "Dein Browser wird geprüft!" title comes from the Anubis bot protection running in front of pmb.acdh.oeaw.ac.at — Citoid never receives the actual page (reproducible: `curl "https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/https%3A%2F%2Fpmb.acdh.oeaw.ac.at%2Fapis%2Fentities%2Fentity%2Fperson%2F2121%2Fdetail"` returns `"title": "Making sure you're not a bot!"`). For that, the ACDH-CH sysadmins need to allowlist the Citoid/Zotero translation-server user agents in the Anubis bot policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)