### PR TITLE
feat: adds row counter and CSV/JSON export to most-valuable-entity table

### DIFF
--- a/apis_core/apis_entities/domain_crossing_views.py
+++ b/apis_core/apis_entities/domain_crossing_views.py
@@ -195,6 +195,9 @@ class MostValuableEntityView(EntityCrossingViewMixin, TemplateView):
         df = df.drop_duplicates(subset=["host", "domain", "entity"], keep="first")
         group_cols = ["entity", "entity__name"]
         if etype == "person":
+            # pandas drops NaN group keys by default, which would silently
+            # exclude persons without a first name
+            df["first_name"] = df["first_name"].fillna("")
             group_cols.append("first_name")
         biggest_groups = (
             df.assign(uri_domain=list(zip(df["uri"], df["domain"])))

--- a/apis_core/apis_entities/domain_crossing_views.py
+++ b/apis_core/apis_entities/domain_crossing_views.py
@@ -156,7 +156,7 @@ class MostValuableEntityView(EntityCrossingViewMixin, TemplateView):
             if "first_name" in row:
                 entry["first_name"] = row.get("first_name")
             entry["count"] = row["count"]
-            entry["uris"] = "; ".join(uri for uri, _domain in row["uris"])
+            entry["uris"] = "; ".join(uri for uri, _domain, _color in row["uris"])
             export_rows.append(entry)
         df = pd.DataFrame(export_rows)
         filename = f"{self.export_name}.{export_format}"
@@ -208,9 +208,16 @@ class MostValuableEntityView(EntityCrossingViewMixin, TemplateView):
             .query(f"count >= {threshold}")
         )
 
+        rows = biggest_groups.to_dict(orient="records")
+        for row in rows:
+            row["uris"] = [
+                (uri, domain, DOMAIN_COLORS.get(domain, settings.DEFAULT_COLOR))
+                for uri, domain in row["uris"]
+            ]
+
         context["entity_buttons"] = self._entity_buttons(etype)
         context["entity"] = etype
-        context["rows"] = biggest_groups.to_dict(orient="records")
+        context["rows"] = rows
         context["uri_count"] = items.count()
         return context
 

--- a/apis_core/apis_entities/domain_crossing_views.py
+++ b/apis_core/apis_entities/domain_crossing_views.py
@@ -3,6 +3,7 @@ import pandas as pd
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.db.models import Count
+from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 from django_tables2 import RequestConfig
@@ -136,6 +137,38 @@ class MostValuableEntityView(EntityCrossingViewMixin, TemplateView):
     """ranks entities by domains"""
 
     template_name = "apis_entities/most_valuable_entity.html"
+    export_name = "haeufig_verwendete_entitaeten"
+
+    def get(self, request, *args, **kwargs):
+        context = self.get_context_data(**kwargs)
+        export_format = request.GET.get("_export")
+        if export_format in ("csv", "json"):
+            return self._export(context["rows"], export_format)
+        return self.render_to_response(context)
+
+    def _export(self, rows, export_format):
+        export_rows = []
+        for row in rows:
+            entry = {
+                "id": row["entity"],
+                "name": row.get("entity__name") or "ohne Name",
+            }
+            if "first_name" in row:
+                entry["first_name"] = row.get("first_name")
+            entry["count"] = row["count"]
+            entry["uris"] = "; ".join(uri for uri, _domain in row["uris"])
+            export_rows.append(entry)
+        df = pd.DataFrame(export_rows)
+        filename = f"{self.export_name}.{export_format}"
+        if export_format == "csv":
+            response = HttpResponse(content_type="text/csv")
+            response["Content-Disposition"] = f'attachment; filename="{filename}"'
+            df.to_csv(response, index=False)
+        else:
+            response = HttpResponse(content_type="application/json")
+            response["Content-Disposition"] = f'attachment; filename="{filename}"'
+            df.to_json(response, orient="records", force_ascii=False)
+        return response
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -146,6 +179,8 @@ class MostValuableEntityView(EntityCrossingViewMixin, TemplateView):
             threshold = 2
         items = ENTITY_TYPES[etype][0].objects.all()
         values_list = ["uri__uri", "uri__domain", "name", "id"]
+        if etype == "person":
+            values_list.append("first_name")
         qs = items.values_list(*values_list)
         df = pd.DataFrame(list(qs), columns=values_list)
         df = df.rename(
@@ -158,9 +193,12 @@ class MostValuableEntityView(EntityCrossingViewMixin, TemplateView):
         )
         df["host"] = df["uri"].str.extract(r"https?://([^/]+)")
         df = df.drop_duplicates(subset=["host", "domain", "entity"], keep="first")
+        group_cols = ["entity", "entity__name"]
+        if etype == "person":
+            group_cols.append("first_name")
         biggest_groups = (
             df.assign(uri_domain=list(zip(df["uri"], df["domain"])))
-            .groupby(["entity", "entity__name"])
+            .groupby(group_cols)
             .agg(
                 count=("entity", "size"),
                 uris=("uri_domain", list),

--- a/apis_core/apis_entities/templates/apis_entities/most_valuable_entity.html
+++ b/apis_core/apis_entities/templates/apis_entities/most_valuable_entity.html
@@ -9,7 +9,7 @@
         <i class="bi bi-intersect"></i> Häufig verwendete Entitäten
     </h1>
     <p class="text-center text-muted">
-        Enititäten die in mehreren Projekten verwednet werden finden.
+        Hier sind jene Entitäten aufgeführt, für die es die meisten URIs (Uniform Resource Identifier, deutsch: einheitlicher Ressourcenbezeichner) in unterschiedlichen Projekten gibt.
     </p>
 
     <div class="row pt-2">
@@ -26,15 +26,17 @@
                 <table class="table table-hover">
                     <thead>
                         <tr>
-                            <th scope="col">Entität</th>
-                            <th scope="col">Uris</th>
+                            <th scope="col" class="text-start">#</th>
+                            <th scope="col" class="text-start">Entität</th>
+                            <th scope="col" class="text-start">Uris</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for row in rows %}
                         <tr>
-                            <th scope="row">
-                                <a href="/entity/{{ row.entity }}">{{ row.entity__name|default:"ohne Name" }}</a>
+                            <td class="text-start">{{ forloop.counter }}</td>
+                            <th scope="row" class="text-start fw-normal">
+                                <a href="/entity/{{ row.entity }}">{{ row.entity__name|default:"ohne Name" }}{% if row.first_name %}, {{ row.first_name }}{% endif %}</a>
                             </th>
                             <td>
                                 <details>
@@ -54,12 +56,24 @@
                         </tr>
                         {% empty %}
                         <tr>
-                            <td colspan="3" class="text-muted">Keine Entitäten gefunden.</td>
+                            <td colspan="4" class="text-muted">Keine Entitäten gefunden.</td>
                         </tr>
                         {% endfor %}
                     </tbody>
                 </table>
             </div>
+            {% if rows %}
+            <div class="dropdown float-end mt-2">
+                <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                    <i class="bi bi-download" title="Tabelle herunterladen"></i>
+                    Download
+                </button>
+                <ul class="dropdown-menu">
+                    <li><a class="dropdown-item" href="{% querystring _export="csv" %}">CSV</a></li>
+                    <li><a class="dropdown-item" href="{% querystring _export="json" %}">JSON</a></li>
+                </ul>
+            </div>
+            {% endif %}
         </div>
 
 

--- a/apis_core/apis_entities/templates/apis_entities/most_valuable_entity.html
+++ b/apis_core/apis_entities/templates/apis_entities/most_valuable_entity.html
@@ -6,7 +6,7 @@
 {% include "partials/entity_styles.html" %}
 <div class="container pt-2">
     <h1 class="display-1 text-center apis-{{ entity }}">
-        <i class="bi bi-intersect"></i> Häufig verwendete Entitäten
+        <i class="bi bi-bar-chart-fill"></i> Häufig verwendete Entitäten
     </h1>
     <p class="text-center text-muted">
         Hier sind jene Entitäten aufgeführt, für die es die meisten URIs (Uniform Resource Identifier, deutsch: einheitlicher Ressourcenbezeichner) in unterschiedlichen Projekten gibt.
@@ -38,20 +38,20 @@
                             <th scope="row" class="text-start fw-normal">
                                 <a href="/entity/{{ row.entity }}">{{ row.entity__name|default:"ohne Name" }}{% if row.first_name %}, {{ row.first_name }}{% endif %}</a>
                             </th>
-                            <td>
+                            <td class="text-start">
                                 <details>
                                     <summary>{{ row.count }}</summary>
 
-                                    <ul class="list-unstyled mb-0">
-
-                                        {% for uri, domain in row.uris %}
-                                        <li>
-                                            <a href="{{ uri }}" target="_blank" rel="noopener noreferrer">{{ domain }}</a>
-                                        </li>
+                                    <div class="d-flex flex-column gap-1 mt-2">
+                                        {% for uri, domain, color in row.uris %}
+                                        <a href="{{ uri }}" target="_blank" rel="noopener noreferrer"
+                                           class="badge text-white text-decoration-none align-self-start"
+                                           style="background-color:{{ color }};">
+                                            {{ domain }}
+                                        </a>
                                         {% endfor %}
-                                    </ul>
-
-                                    </detail>
+                                    </div>
+                                </details>
                             </td>
                         </tr>
                         {% empty %}

--- a/apis_core/apis_entities/tests.py
+++ b/apis_core/apis_entities/tests.py
@@ -1,3 +1,5 @@
+import json
+
 from AcdhArcheAssets.uri_norm_rules import get_normalized_uri
 from django.apps import apps
 from django.conf import settings
@@ -888,3 +890,27 @@ class MostValuableEntityViewTestCase(TestCase):
         self.assertEqual(row["entity__name"], self.person.name)
         self.assertEqual(row["count"], 15)
         self.assertEqual(len(row["uris"]), 15)
+
+    def test_export_csv(self):
+        url = reverse("apis:apis_entities:mvp")
+        response = self.client.get(f"{url}?type=person&_export=csv")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+        self.assertIn("attachment;", response["Content-Disposition"])
+        content = response.content.decode()
+        self.assertIn(self.person.name, content)
+        self.assertIn("15", content)
+
+    def test_export_json(self):
+        url = reverse("apis:apis_entities:mvp")
+        response = self.client.get(f"{url}?type=person&_export=json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/json")
+        self.assertIn("attachment;", response["Content-Disposition"])
+        data = json.loads(response.content)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["id"], self.person.pk)
+        self.assertEqual(data[0]["name"], self.person.name)
+        self.assertEqual(data[0]["count"], 15)

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -75,8 +75,8 @@
                             </li>
                             <li>
                                 <a class="dropdown-item" href="{% url 'apis:apis_entities:mvp' %}">
-                                    <i class="bi bi-intersect"></i>
-                                    Oft verwendete Entitäten
+                                    <i class="bi bi-bar-chart-fill"></i>
+                                    Häufigste Entitäten
                                 </a>
                             </li>
                             {% endif %}


### PR DESCRIPTION
## Summary
- Left-aligns and un-bolds the entity column; shows first names for persons
- Adds a running counter (#) as the first column
- Adds CSV/JSON download of the results, respecting the current entity-type filter

## Test plan
- [ ] Visit `/entity/most-valuable/` (or equivalent URL) for each entity type and check the table layout
- [ ] Click through the Download dropdown and verify CSV and JSON downloads contain the expected rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)